### PR TITLE
Fix #4 and enable `codesign` to interoperate with `qemu`-upstream's `entitlement.sh` script.

### DIFF
--- a/codesign.cpp
+++ b/codesign.cpp
@@ -9,7 +9,7 @@ int main(int argc, char **argv) {
     std::vector<std::string> files;
     app.add_option("-s", identity, "Code signing identity")->required();
     app.add_option("-i,--identifier", identifier, "File identifier");
-    app.add_flag("-f", force, "Replace any existing signatures");
+    app.add_flag("-f,--force", force, "Replace any existing signatures");
     app.add_option("--entitlements", entitlements, "Entitlements plist");
     app.add_option("files", files, "Files to sign");
 


### PR DESCRIPTION
This PR fixes #4 in the sense that it enables `sigtool`'s C++ `codesign` implementation to interoperate with upstream qemu's [`entitlement.sh`](https://gitlab.com/qemu-project/qemu/-/blob/master/scripts/entitlement.sh) driver script, notably by adding support for the `--force` synonym for the `-f` option added in  9a2ec3f0de130b8d25247e7dd4605d20d93ad5bb and by fixing a bug in the way that `codesign` was coordinating with `codesign_allocate` via temporary files.

Tested via https://github.com/mstone/qemu-m1/commit/076cae62b6da3b0fffd40f6fc2171554f09df0b1 and https://github.com/mstone/sigtool/commit/9888891984a9cd4b795cc6f391356f57de3e6a63 (although these test refs contain commits with a couple of additional only tangentially-related changes for debugging convenience and for exploring what will be needed to enable `hvf` acceleration support in [`nixpkgs`](https://github.com/nixos/nixpkgs) `aarch64-darwin` packaging of `qemu`, e.g. partially re: nixos/nixpkgs#135877 + nixos/nixpkgs#121903 that are not, by themselves, needed for this PR.)