### PR TITLE
codesign: implement --remove-signature for thin Mach-O

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Subcommands:
   generate                    Generate an embedded signature and emit on stdout
   inject                      Generate and inject embedded signature
   show-arch                   Show architecture
+  remove-signature            Remove an existing embedded code signature (thin only)
 ```
 
 ### codesign
@@ -46,11 +47,18 @@ Positionals:
 
 Options:
   -h,--help                   Print this help message and exit
-  -s TEXT REQUIRED            Code signing identity
+  -s,--sign TEXT              Code signing identity (required unless --remove-signature)
   -i,--identifier TEXT        File identifier
   -f,--force                  Replace any existing signatures
   --entitlements TEXT         Entitlements plist
+  --remove-signature          Remove any existing code signature (thin Mach-O only)
 ```
+
+`--remove-signature` produces the same bytes as Apple's `codesign
+--remove-signature` for thin Mach-O files: the `LC_CODE_SIGNATURE`
+load command is dropped, `__LINKEDIT.filesize` is shrunk to the end of
+the remaining linker tables, and the signature blob plus any alignment
+padding is truncated from the file. Fat binaries are not yet supported.
 
 
 ## Example signature

--- a/codesign.cpp
+++ b/codesign.cpp
@@ -6,15 +6,31 @@ int main(int argc, char **argv) {
 
     std::string identity, identifier, entitlements;
     bool force = false;
+    bool removeSignature = false;
     std::vector<std::string> files;
-    app.add_option("-s,--sign", identity, "Code signing identity")->required();
+    auto *signOpt = app.add_option("-s,--sign", identity, "Code signing identity");
     app.add_option("-i,--identifier", identifier, "File identifier");
     app.add_flag("-f,--force", force, "Replace any existing signatures");
     app.add_option("--entitlements", entitlements, "Entitlements plist");
+    app.add_flag("--remove-signature", removeSignature,
+                 "Remove any existing code signature from the target file");
     app.add_option("files", files, "Files to sign");
 
     CLI11_PARSE(app, argc, argv);
 
+    if (removeSignature) {
+        if (*signOpt) {
+            throw std::runtime_error{"--remove-signature is mutually exclusive with --sign"};
+        }
+        for (const auto &f : files) {
+            SigTool::Commands::removeSignature(f);
+        }
+        return 0;
+    }
+
+    if (!*signOpt) {
+        throw std::runtime_error{"--sign is required unless --remove-signature is given"};
+    }
     if (identity != std::string{"-"}) {
         throw std::runtime_error{
                 std::string{"Only ad-hoc identities supported, requested: '"} + identity + "'"};

--- a/commands.cpp
+++ b/commands.cpp
@@ -1,8 +1,10 @@
 #include <algorithm>
+#include <cstddef>
 #include <cstring>
 #include <memory>
 #include <string>
 #include <sstream>
+#include <vector>
 #include <sys/stat.h>
 #include <spawn.h>
 #include <unistd.h>
@@ -351,6 +353,179 @@ int Commands::codesign(const CodesignOptions &options, const std::string &filena
     // rename temp file to output
     if (rename(tempfileName.get(), filename.c_str()) != 0) {
         throw std::runtime_error{"rename failed"};
+    }
+
+    return 0;
+}
+
+// Highest file offset referenced by tables living inside __LINKEDIT.
+// Needed because codesign_allocate rejects files where __LINKEDIT extends
+// past the actual linker data, so we must shrink filesize to the end of
+// the tables rather than to where the signature started (which includes
+// alignment padding).
+static uint64_t computeLinkeditEnd(const std::string &filename,
+                                   off_t lcAreaStart,
+                                   uint32_t nCommands,
+                                   uint64_t linkeditStart,
+                                   uint64_t linkeditEnd) {
+    enum : uint32_t {
+        LC_SYMTAB_T = 0x02,
+        LC_DYSYMTAB_T = 0x0b,
+        LC_FUNCTION_STARTS_T = 0x26,
+        LC_DATA_IN_CODE_T = 0x29,
+        LC_DYLIB_CODE_SIGN_DRS_T = 0x2b,
+        LC_LINKER_OPT_HINT_T = 0x2e,
+        LC_DYLD_EXPORTS_TRIE_T = 0x80000033u,
+        LC_DYLD_CHAINED_FIXUPS_T = 0x80000034u,
+        LC_DYLD_INFO_T = 0x22,
+        LC_DYLD_INFO_ONLY_T = 0x80000022u,
+    };
+
+    std::ifstream f{filename, std::ifstream::in | std::ifstream::binary};
+    if (!f) {
+        throw std::runtime_error{std::string{"re-opening macho: "} + strerror(errno)};
+    }
+
+    uint64_t end = 0;
+    auto consider = [&](uint64_t off, uint64_t size) {
+        if (size == 0) return;
+        if (off < linkeditStart || off >= linkeditEnd) return;
+        if (off + size > end) end = off + size;
+    };
+
+    f.seekg(lcAreaStart);
+    for (uint32_t i = 0; i < nCommands; i++) {
+        off_t start = f.tellg();
+        uint32_t type = ReadLE::readUInt32(f);
+        uint32_t cmdSize = ReadLE::readUInt32(f);
+
+        auto u32 = [&](off_t rel) {
+            f.seekg(start + rel);
+            return ReadLE::readUInt32(f);
+        };
+
+        switch (type) {
+            case LC_SYMTAB_T: {
+                uint32_t symoff = u32(8), nsyms = u32(12);
+                uint32_t stroff = u32(16), strsize = u32(20);
+                consider(symoff, uint64_t(nsyms) * 16); // nlist_64
+                consider(stroff, strsize);
+                break;
+            }
+            case LC_DYSYMTAB_T: {
+                uint32_t tocoff = u32(8 + 32), ntoc = u32(8 + 36);
+                uint32_t modtaboff = u32(8 + 40), nmodtab = u32(8 + 44);
+                uint32_t extrefoff = u32(8 + 48), nextref = u32(8 + 52);
+                uint32_t indsymoff = u32(8 + 56), nindsym = u32(8 + 60);
+                uint32_t extreloff = u32(8 + 64), nextrel = u32(8 + 68);
+                uint32_t locreloff = u32(8 + 72), nlocrel = u32(8 + 76);
+                consider(tocoff, uint64_t(ntoc) * 8);
+                consider(modtaboff, uint64_t(nmodtab) * 56);
+                consider(extrefoff, uint64_t(nextref) * 8);
+                consider(indsymoff, uint64_t(nindsym) * 4);
+                consider(extreloff, uint64_t(nextrel) * 8);
+                consider(locreloff, uint64_t(nlocrel) * 8);
+                break;
+            }
+            case LC_DYLD_INFO_T:
+            case LC_DYLD_INFO_ONLY_T: {
+                for (int k = 0; k < 5; k++) {
+                    uint32_t off = u32(8 + k * 8);
+                    uint32_t size = u32(8 + k * 8 + 4);
+                    consider(off, size);
+                }
+                break;
+            }
+            case LC_FUNCTION_STARTS_T:
+            case LC_DATA_IN_CODE_T:
+            case LC_DYLIB_CODE_SIGN_DRS_T:
+            case LC_LINKER_OPT_HINT_T:
+            case LC_DYLD_EXPORTS_TRIE_T:
+            case LC_DYLD_CHAINED_FIXUPS_T: {
+                uint32_t off = u32(8), size = u32(12);
+                consider(off, size);
+                break;
+            }
+            default:
+                break;
+        }
+
+        f.seekg(start + cmdSize);
+    }
+    return end;
+}
+
+int Commands::removeSignature(const std::string &filename) {
+    MachOList list{filename};
+    if (list.machos.size() != 1) {
+        // Fat would need FatHeader rewriting + slice re-alignment.
+        throw std::runtime_error{
+                "--remove-signature is only supported on thin Mach-O files"};
+    }
+    auto macho = list.machos.front();
+    auto cs = macho->getCodeSignatureLoadCommand();
+    if (!cs) return 0; // matches Apple: exit 0 when already unsigned
+    auto linkedit = macho->getSegment64LoadCommand("__LINKEDIT");
+    if (!linkedit) {
+        throw std::runtime_error{"signed Mach-O has no __LINKEDIT segment"};
+    }
+
+    const off_t lcAreaStart = macho->offset + 4 /*magic*/ + sizeof(MachOHeader);
+    const uint64_t linkeditEnd =
+            linkedit->data.fileoff + linkedit->data.filesize;
+    uint64_t linkerDataEnd = computeLinkeditEnd(
+            filename, lcAreaStart, macho->header.nCommands,
+            linkedit->data.fileoff, linkeditEnd);
+    if (linkerDataEnd == 0) linkerDataEnd = linkedit->data.fileoff;
+
+    std::fstream f{filename, std::ios::in | std::ios::out | std::ios::binary};
+    if (!f) {
+        throw std::runtime_error{std::string{"opening macho file: "} + strerror(errno)};
+    }
+
+    // Drop LC_CODE_SIGNATURE: shift the tail up, zero the freed bytes.
+    const off_t lcAreaEnd = lcAreaStart + macho->header.sizeOfCmds;
+    const off_t csStart = cs->fileOffset;
+    const off_t csEnd = csStart + cs->cmdSize;
+    if (csEnd > lcAreaEnd) {
+        throw std::runtime_error{
+                "malformed Mach-O: LC_CODE_SIGNATURE extends past load command area"};
+    }
+    std::vector<char> tail(static_cast<size_t>(lcAreaEnd - csEnd));
+    if (!tail.empty()) {
+        f.seekg(csEnd);
+        f.read(tail.data(), tail.size());
+        if (f.fail()) {
+            throw std::runtime_error{"reading load command tail"};
+        }
+    }
+    f.clear();
+    f.seekp(csStart);
+    if (!tail.empty()) {
+        f.write(tail.data(), tail.size());
+    }
+    std::vector<char> zeros(cs->cmdSize, 0);
+    f.write(zeros.data(), zeros.size());
+
+
+    uint32_t newNCommands = macho->header.nCommands - 1;
+    uint32_t newSizeOfCmds = macho->header.sizeOfCmds - cs->cmdSize;
+    f.seekp(macho->offset + 4 /*magic*/ + offsetof(MachOHeader, nCommands));
+    f.write(reinterpret_cast<const char *>(&newNCommands), 4);
+    f.write(reinterpret_cast<const char *>(&newSizeOfCmds), 4);
+
+    // Shrink __LINKEDIT.filesize; leave vmsize alone (page size varies).
+    // Segment64 layout after 8-byte LC header: segname[16] vmaddr vmsize
+    // fileoff filesize (all u64) -> filesize at +8+40.
+    uint64_t newFilesize = linkerDataEnd - linkedit->data.fileoff;
+    f.seekp(linkedit->fileOffset + 8 + 40);
+    f.write(reinterpret_cast<const char *>(&newFilesize), 8);
+
+    f.flush();
+    f.close();
+
+    if (truncate(filename.c_str(), linkerDataEnd) != 0) {
+        throw std::runtime_error{std::string{"truncate: "} + strerror(errno)};
     }
 
     return 0;

--- a/commands.h
+++ b/commands.h
@@ -23,6 +23,7 @@ namespace Commands {
     int inject(const SignOptions& options);
     int generate(const SignOptions& options);
     int codesign(const CodesignOptions& options, const std::string& file);
+    int removeSignature(const std::string& file);
 };
 };
 

--- a/macho.cpp
+++ b/macho.cpp
@@ -71,12 +71,13 @@ MachO::MachO(std::ifstream &f, off_t offset, size_t size) : header{}, offset{off
         uint32_t type = ReadLE::readUInt32(f);
         uint32_t cmdSize = ReadLE::readUInt32(f);
 
+        std::shared_ptr<LoadCommand> lc;
         switch (type) {
             case LC_SEGMENT_64: {
                 auto lcSegment = std::make_shared<Segment64LoadCommand>(type, cmdSize);
                 f.read(reinterpret_cast<char *>(&lcSegment->data),
                        sizeof(Segment64LoadCommand::data));
-                loadCommands.push_back(lcSegment);
+                lc = lcSegment;
                 break;
             }
 
@@ -84,14 +85,15 @@ MachO::MachO(std::ifstream &f, off_t offset, size_t size) : header{}, offset{off
                 auto lcCodeSignature = std::make_shared<CodeSignatureLoadCommand>(type, cmdSize);
                 f.read(reinterpret_cast<char *>(&lcCodeSignature->data),
                        sizeof(CodeSignatureLoadCommand::data));
-                loadCommands.push_back(lcCodeSignature);
+                lc = lcCodeSignature;
                 break;
             }
 
             default:
-                auto lc = std::make_shared<LoadCommand>(type, cmdSize);
-                loadCommands.push_back(lc);
+                lc = std::make_shared<LoadCommand>(type, cmdSize);
         }
+        lc->fileOffset = start;
+        loadCommands.push_back(lc);
 
         size_t actualRead = f.tellg() - start;
 

--- a/macho.h
+++ b/macho.h
@@ -77,6 +77,7 @@ struct FatHeader {
 struct LoadCommand {
     uint32_t type;
     uint32_t cmdSize;
+    off_t fileOffset = 0; // absolute offset in file; set by MachO ctor
 
     explicit LoadCommand(uint32_t type, uint32_t cmdSize) : type(type), cmdSize(cmdSize) {};
 };

--- a/main.cpp
+++ b/main.cpp
@@ -18,6 +18,8 @@ int main(int argc, char **argv) {
     app.add_subcommand("generate", "Generate an embedded signature and emit on stdout");
     app.add_subcommand("inject", "Generate and inject embedded signature");
     app.add_subcommand("show-arch", "Show architecture");
+    app.add_subcommand("remove-signature",
+                       "Remove an existing embedded code signature");
 
     app.require_subcommand();
 
@@ -27,6 +29,8 @@ int main(int argc, char **argv) {
         return SigTool::Commands::checkRequiresSignature(file);
     } else if (app.got_subcommand("show-arch")) {
         return SigTool::Commands::showArch(file);
+    } else if (app.got_subcommand("remove-signature")) {
+        return SigTool::Commands::removeSignature(file);
     }
 
     SigTool::Commands::SignOptions options{

--- a/test/test.sh
+++ b/test/test.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-mkdir -p resigned tmp apple_signed
+mkdir -p resigned tmp apple_signed stripped
 
 archs=(arm64-darwin x86_64-darwin)
 
@@ -50,8 +50,48 @@ resign() {
   echo
 }
 
+# Check --remove-signature matches Apple byte-for-byte and that the
+# stripped file re-signs and verifies. Thin only.
+remove_roundtrip() {
+  local input=$1
+  local name
+  name=$(basename "$input")
+
+  echo "Strip-and-resign: $name"
+
+  local ours=stripped/$name.ours
+  local theirs=stripped/$name.theirs
+  cp "$input" "$ours"
+  cp "$input" "$theirs"
+
+  # Our drop-in matches Apple byte-for-byte on thin Mach-O.
+  "$(dirname "$0")/../codesign" --remove-signature "$ours"
+  /usr/bin/codesign --remove-signature "$theirs"
+  if ! cmp -s "$ours" "$theirs"; then
+    echo "FAIL: --remove-signature output differs from Apple's for $name"
+    failures+=("$name-strip")
+    echo
+    return
+  fi
+
+  # Stripped file must be re-signable and the result must verify.
+  if CODESIGN_ALLOCATE=codesign_allocate \
+       "$(dirname "$0")/../codesign" -s - -f "$ours" \
+     && codesign --verify -vvv "$ours"; then
+    echo "OK: $name-strip"
+  else
+    echo "FAIL: re-sign after strip failed for $name"
+    failures+=("$name-strip")
+  fi
+  echo
+}
+
 for f in "${files[@]}"; do
   resign "$f"
+done
+
+for arch in "${archs[@]}"; do
+  remove_roundtrip "tmp/test.$arch"
 done
 
 if [ "${#failures[@]}" -eq 0 ]; then


### PR DESCRIPTION
Lets downstream users (nixpkgs, nix-installer) strip and re-sign inside a Nix sandbox without `/usr/bin/codesign`.

Fat binaries would additionally require rewriting the `FatHeader` sizes and re-aligning subsequent slices, so they are explicitly rejected for now.