### PR TITLE
Fix build with GCC

### DIFF
--- a/emit.h
+++ b/emit.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <arpa/inet.h>
 #include <cmath>
+#include <cstdint>
 
 namespace SigTool {
 


### PR DESCRIPTION
Import @reckenrode 's GCC building patch from nixpkgs https://github.com/NixOS/nixpkgs/blob/16d3b402cfe4a58a4a1c344d1937eda81dbd329c/pkgs/os-specific/darwin/by-name/si/sigtool/0001-fix-build-with-gcc.patch