### PR TITLE
Add --timestamp=none support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,13 @@ Options:
   -f,--force                  Replace any existing signatures
   --entitlements TEXT         Entitlements plist
   --generate-entitlement-der  Also embed DER-encoded entitlements
+  --timestamp[=none]          Accepted for compatibility; only =none is supported
 ```
 
+`--timestamp=none` is accepted as a no-op so build tools that pass it can call
+this `codesign` unmodified. Real TSA timestamping is not supported because
+ad-hoc signatures contain no CMS signature for a timestamp authority to
+countersign.
 
 ## Example signature
 

--- a/codesign.cpp
+++ b/codesign.cpp
@@ -4,7 +4,7 @@
 int main(int argc, char **argv) {
     CLI::App app{"codesign"};
 
-    std::string identity, identifier, entitlements;
+    std::string identity, identifier, entitlements, timestamp;
     bool force = false;
     bool generateEntitlementDER = false;
     std::vector<std::string> files;
@@ -14,9 +14,24 @@ int main(int argc, char **argv) {
     app.add_option("--entitlements", entitlements, "Entitlements plist");
     app.add_flag("--generate-entitlement-der", generateEntitlementDER,
                  "Also embed DER-encoded entitlements");
+    // Apple's --timestamp takes an optional joined value only:
+    //   --timestamp        request default TSA (not supported here)
+    //   --timestamp=none   suppress timestamping (no-op for ad-hoc)
+    //   --timestamp=URL    request a specific TSA (not supported here)
+    // A string-valued flag matches that shape: it accepts a '='-joined value
+    // but never consumes the following argument. A bare --timestamp yields
+    // "true", which is rejected below like any value other than "none".
+    app.add_flag("--timestamp", timestamp,
+                 "Timestamp options; only '--timestamp=none' is supported");
     app.add_option("files", files, "Files to sign");
 
     CLI11_PARSE(app, argc, argv);
+
+    if (!timestamp.empty() && timestamp != "none") {
+        throw std::runtime_error{
+                std::string{"--timestamp only supports '=none' (TSA timestamping "
+                            "is not available with ad-hoc signatures)"}};
+    }
 
     if (identity != std::string{"-"}) {
         throw std::runtime_error{


### PR DESCRIPTION
Another option required for building using swift-build.
It's just a noop since we don't do timestamps and nix really doesn't need it for default builds.